### PR TITLE
Add Dirpicker, to choose where to store attachments with Ranger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # NeomuttFilePicker
-Attach files to your emails in [NeoMutt](https://github.com/neomutt/) using [Ranger](https://github.com/ranger/ranger) or [Vifm](https://github.com/vifm) as your file manager.
 
-This script is based on the [this topic](https://www.reddit.com/r/commandline/comments/cbxvdf/combine_neomutt_with_ranger/) and improved to allow attaching mulptiple files with spaces in the name and path.
+- Attach files to your emails in [NeoMutt](https://github.com/neomutt/) using [Ranger](https://github.com/ranger/ranger) or [Vifm](https://github.com/vifm) as your file manager.
+- Choose a directory to store attachments with Ranger
 
-## Usage
+The main script is based on the [this topic](https://www.reddit.com/r/commandline/comments/cbxvdf/combine_neomutt_with_ranger/) and improved to allow attaching mulptiple files with spaces in the name and path.
+
+## Usage of Filepicker
 1. Copy the "filepicker" file to your .config/mutt or wherewher is your config directory.
 2. Add the following line to your .muttrc so that you can attach files with `A`
 
@@ -12,9 +14,23 @@ macro compose A "<shell-escape>bash $HOME/.config/mutt/filepick<enter><enter-com
 ```
 3. Now, on the email sending screen (when you already wrote the text and saved it) type `A` instead of standard `a` to call the script. The file manager should appear. Choose files that you want to attach (tag them if multiple files) and hit Enter. Hit Enter twice more when asked. 
 
+## Usage of Dirpicker
+1. Copy the "dirpicker" file to your .config/mutt or wherewher is your config directory.
+2. Add the following line to your .muttrc so that you can choose the folder
+   where to store files with `S`
+
+```
+macro attach S "<shell-escape>bash $HOME/.mutt/neomutt-file-picker/dirpicker<enter><enter-command>source $HOME/.mutt/tmpfile<enter>o" "Choose folder with ranger"
+```
+3. Now, on the attachment screen (by default, reached with `v`), type `S` instead of standard `s` to call the script. The file manager should appear. Choose the folder with ranger, quit with `q`. Mutt may then ask for the filename in the folder. 
+
 ## Settings
+
 In the "filepicker" file you can choose which file manager to use. Vifm by default, but you can uncomment Ranger and comment Vifm if you like.
 
 ## Issues
 - You should start NeoMutt from your home directory, otherwise you won't be able to attach files.
 - You might need to make the script executable if you have error about permissions.
+
+## TODO 
+- The dirpicker should be adapted to handle several attachments at once (perhaps with ripmime or munpack?)

--- a/dirpicker
+++ b/dirpicker
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+tmpfile=.mutt/tmpfile
+    
+if \[ -z "$1" \]; then
+    ranger --choosedir $tmpfile &&    # Use Ranger
+    #vifm --choose-files $tmpfile &&       # Use Vifm
+    sed -i 's/ /^V /g' $tmpfile &&
+    echo "$(awk 'BEGIN {printf "%s", "push "} {printf "%s", "<save-entry>\""$0"\"<enter>"}'  $tmpfile)" > $tmpfile
+elif \[ $1 == "clean" \]; then
+    rm $tmpfile
+fi


### PR DESCRIPTION
Following the main script, I add a dirpicker, to select a folder with ranger, for storing attachments. 
Ranger is better than the mutt file explorer because there are shortcuts and fzf-marks plugins, to allow for efficient navigation.

Issue: currently, it does not accept to handle multiple attachments. I tried a bit, to no avail.